### PR TITLE
Add numeric header to histogrammar

### DIFF
--- a/cpp/include/histogrammar.hpp
+++ b/cpp/include/histogrammar.hpp
@@ -21,7 +21,7 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
-
+#include <numeric>
 #include "json.hpp"
 
 using json = nlohmann::json;


### PR DESCRIPTION
Hi, I added the <numeric> header as that is technically where std::iota is to be found. It will work without <numeric> on some compilers but not all, but with <numeric> it should work everywhere. Found out because it didn't want to compile on g++ 5.3.1, but works on g++4.9.3 without issues. 
See: [https://www.daniweb.com/programming/software-development/threads/421379/stl-iota-not-found](url)