### PR TITLE
Basic python 3 compatability changes

### DIFF
--- a/python/histogrammar/primitives/centralbin.py
+++ b/python/histogrammar/primitives/centralbin.py
@@ -56,7 +56,7 @@ class CentrallyBin(Factory, Container, CentralBinsDistribution, CentrallyBinMeth
         super(CentrallyBin, self).__init__()
 
     def zero(self):
-        return CentrallyBin(map(lambda x, v: x, self.bins), self.quantity, self.value, self.nanflow.zero())
+        return CentrallyBin(map(lambda x: x[0], self.bins), self.quantity, self.value, self.nanflow.zero())
 
     def __add__(self, other):
         if self.centers != other.centers:
@@ -64,7 +64,7 @@ class CentrallyBin(Factory, Container, CentralBinsDistribution, CentrallyBinMeth
 
         newbins = [(c1, v1 + v2) for (c1, v1), (_, v2) in zip(self.bins, other.bins)]
 
-        out = CentrallyBin(map(lambda x, v: x, self.bins), self.quantity, self.value, self.nanflow + other.nanflow)
+        out = CentrallyBin(map(lambda x: x[0], self.bins), self.quantity, self.value, self.nanflow + other.nanflow)
         out.entries = self.entries + other.entries
         out.bins = newbins
         out.min = minplus(self.min, other.min)

--- a/python/histogrammar/primitives/centralbin.py
+++ b/python/histogrammar/primitives/centralbin.py
@@ -56,7 +56,7 @@ class CentrallyBin(Factory, Container, CentralBinsDistribution, CentrallyBinMeth
         super(CentrallyBin, self).__init__()
 
     def zero(self):
-        return CentrallyBin(map(lambda (x, v): x, self.bins), self.quantity, self.value, self.nanflow.zero())
+        return CentrallyBin(map(lambda x, v: x, self.bins), self.quantity, self.value, self.nanflow.zero())
 
     def __add__(self, other):
         if self.centers != other.centers:
@@ -64,7 +64,7 @@ class CentrallyBin(Factory, Container, CentralBinsDistribution, CentrallyBinMeth
 
         newbins = [(c1, v1 + v2) for (c1, v1), (_, v2) in zip(self.bins, other.bins)]
 
-        out = CentrallyBin(map(lambda (x, v): x, self.bins), self.quantity, self.value, self.nanflow + other.nanflow)
+        out = CentrallyBin(map(lambda x, v: x, self.bins), self.quantity, self.value, self.nanflow + other.nanflow)
         out.entries = self.entries + other.entries
         out.bins = newbins
         out.min = minplus(self.min, other.min)

--- a/python/histogrammar/primitives/collection.py
+++ b/python/histogrammar/primitives/collection.py
@@ -245,7 +245,7 @@ class Label(Factory, Container):
             raise ContainerException("all Label keys must be strings")
         if len(pairs) < 1:
             raise ContainerException("at least one pair required")
-        contentType = pairs.values()[0].name
+        contentType = list(pairs.values())[0].name
         if any(x.name != contentType for x in pairs.values()):
             raise ContainerException("all Label values must have the same type")
 
@@ -295,7 +295,7 @@ class Label(Factory, Container):
 
     def toJsonFragment(self): return {
         "entries": floatToJson(self.entries),
-        "type": self.values[0].name,
+        "type": list(self.values)[0].name,
         "data": {k: v.toJsonFragment() for k, v in self.pairs.items()},
         }
 

--- a/python/histogrammar/primitives/sample.py
+++ b/python/histogrammar/primitives/sample.py
@@ -111,7 +111,7 @@ class Sample(Factory, Container):
     def toJsonFragment(self): return maybeAdd({
         "entries": floatToJson(self.entries),
         "limit": floatToJson(self.limit),
-        "values": [{"w": w, "v": y} for y, w in sorted(self.values, key=lambda (y, w): y)],
+        "values": [{"w": w, "v": y} for y, w in sorted(self.values, key=lambda y_w: y_w[0])],
         }, name=self.quantity.name)
 
     @staticmethod

--- a/python/histogrammar/util.py
+++ b/python/histogrammar/util.py
@@ -470,9 +470,9 @@ class CentrallyBinMethods(object):
     @property
     def centersSet(self): return set(self.centers)
     @property
-    def centers(self): return map(lambda (x, v): x, self.bins)
+    def centers(self): return map(lambda x, v: x, self.bins)
     @property
-    def values(self): return map(lambda (x, v): v, self.bins)
+    def values(self): return map(lambda x, v: v, self.bins)
 
     def index(self, x):
         closestIndex = bisect.bisect_left(self.bins, (x, LessThanEverything()))

--- a/python/histogrammar/util.py
+++ b/python/histogrammar/util.py
@@ -479,9 +479,9 @@ class CentrallyBinMethods(object):
     @property
     def centersSet(self): return set(self.centers)
     @property
-    def centers(self): return map(lambda x, v: x, self.bins)
+    def centers(self): return map(lambda x: x[0], self.bins)
     @property
-    def values(self): return map(lambda x, v: v, self.bins)
+    def values(self): return map(lambda x: x[0], self.bins)
 
     def index(self, x):
         closestIndex = bisect.bisect_left(self.bins, (x, LessThanEverything()))

--- a/python/histogrammar/util.py
+++ b/python/histogrammar/util.py
@@ -20,6 +20,15 @@ import marshal
 import math
 import random
 import types
+import sys
+
+
+
+# Definitions for python 2/3 compatability 
+if sys.version_info[0] > 2:
+    basestring = str
+    xrange = range
+
 
 @functools.total_ordering
 class LessThanEverything(object):

--- a/python/histogrammar/util.py
+++ b/python/histogrammar/util.py
@@ -28,7 +28,7 @@ import sys
 if sys.version_info[0] > 2:
     basestring = str
     xrange = range
-
+    long = int
 
 @functools.total_ordering
 class LessThanEverything(object):

--- a/python/histogrammar/util.py
+++ b/python/histogrammar/util.py
@@ -184,8 +184,8 @@ class UserFcn(object):
             return (deserializeString, (self.__class__, self.expr, self.name))
 
         elif isinstance(self.expr, types.FunctionType):
-            refs = {n: self.expr.func_globals[n] for n in self.expr.func_code.co_names if n in self.expr.func_globals}
-            return (deserializeFunction, (self.__class__, marshal.dumps(self.expr.func_code), self.expr.func_name, self.expr.func_defaults, self.expr.func_closure, refs, self.name))
+            refs = {n: self.expr.__globals__[n] for n in self.expr.__code__.co_names if n in self.expr.__globals__}
+            return (deserializeFunction, (self.__class__, marshal.dumps(self.expr.__code__), self.expr.__name__, self.expr.__defaults__, self.expr.__closure__, refs, self.name))
 
         else:
             raise TypeError("unrecognized type for function: {}".format(type(self.expr)))
@@ -197,7 +197,7 @@ class UserFcn(object):
         out = isinstance(other, UserFcn) and self.name == other.name
 
         if isinstance(self.expr, types.FunctionType) and isinstance(other.expr, types.FunctionType):
-            out = out and (self.expr.func_code.co_code == other.expr.func_code.co_code)
+            out = out and (self.expr.__code__.co_code == other.expr.__code__.co_code)
         else:
             out = out and (self.expr == other.expr)
 
@@ -205,7 +205,7 @@ class UserFcn(object):
 
     def __hash__(self):
         if isinstance(self.expr, types.FunctionType):
-            return hash((None, self.expr.func_code.co_code, self.name))
+            return hash((None, self.expr.__code__.co_code, self.name))
         else:
             return hash((self.expr, self.name))
 
@@ -228,10 +228,10 @@ def deserializeString(cls, expr, name):
     out.name = name
     return out
 
-def deserializeFunction(cls, func_code, func_name, func_defaults, func_closure, refs, name):
+def deserializeFunction(cls, __code__, __name__, __defaults__, __closure__, refs, name):
     out = cls.__new__(cls)
     g = dict(globals(), **refs)
-    out.expr = types.FunctionType(marshal.loads(func_code), g, func_name, func_defaults, func_closure)
+    out.expr = types.FunctionType(marshal.loads(__code__), g, __name__, __defaults__, __closure__)
     out.name = name
     return out
 

--- a/python/test/test.py
+++ b/python/test/test.py
@@ -62,6 +62,7 @@ class TestEverything(unittest.TestCase):
         if not any(_ > 0.0 for _ in w):
             return 0.0
         else:
+            w = list(w)
             return sum(xi * max(wi, 0.0) for xi, wi in zip(x, w)) / sum(_ for _ in w if _ > 0.0)
 
     @staticmethod
@@ -76,6 +77,7 @@ class TestEverything(unittest.TestCase):
         if not any(_ > 0.0 for _ in w):
             return 0.0
         else:
+            w = list(w)
             return sum(xi**2 * max(wi, 0.0) for xi, wi in zip(x, w)) / sum(_ for _ in w if _ > 0.0) - math.pow(sum(xi * max(wi, 0.0) for xi, wi in zip(x, w)) / sum(_ for _ in w if _ > 0.0), 2)
 
     @staticmethod
@@ -130,12 +132,12 @@ class TestEverything(unittest.TestCase):
             for _ in left: leftCounting.fill(_)
             for _ in right: rightCounting.fill(_)
 
-            self.assertEqual(leftCounting.value.entries, len(filter(lambda x: x > 0.0, left)))
-            self.assertEqual(rightCounting.value.entries, len(filter(lambda x: x > 0.0, right)))
+            self.assertEqual(leftCounting.value.entries, len(list(filter(lambda x: x > 0.0, left))))
+            self.assertEqual(rightCounting.value.entries, len(list(filter(lambda x: x > 0.0, right))))
 
             finalResult = leftCounting + rightCounting
 
-            self.assertEqual(finalResult.value.entries, len(filter(lambda x: x > 0.0, self.simple)))
+            self.assertEqual(finalResult.value.entries, len(list(filter(lambda x: x > 0.0, self.simple))))
 
             self.checkJson(leftCounting)
             self.checkJson(leftCounting)
@@ -615,7 +617,7 @@ class TestEverything(unittest.TestCase):
     def testBin(self):
         one = Bin(5, -3.0, 7.0, named("something", lambda x: x))
         for _ in self.simple: one.fill(_)
-        self.assertEqual(map(lambda _: _.entries, one.values), [3.0, 2.0, 2.0, 1.0, 0.0])
+        self.assertEqual(list(map(lambda _: _.entries, one.values)), [3.0, 2.0, 2.0, 1.0, 0.0])
         self.assertEqual(one.underflow.entries, 1.0)
         self.assertEqual(one.overflow.entries, 1.0)
         self.assertEqual(one.nanflow.entries, 0.0)
@@ -623,7 +625,7 @@ class TestEverything(unittest.TestCase):
         two = Select(lambda x: x.bool, Bin(5, -3.0, 7.0, lambda x: x.double))
         for _ in self.struct: two.fill(_)
 
-        self.assertEqual(map(lambda _: _.entries, two.value.values), [2.0, 1.0, 1.0, 1.0, 0.0])
+        self.assertEqual(list(map(lambda _: _.entries, two.value.values)), [2.0, 1.0, 1.0, 1.0, 0.0])
         self.assertEqual(two.value.underflow.entries, 0.0)
         self.assertEqual(two.value.overflow.entries, 0.0)
         self.assertEqual(two.value.nanflow.entries, 0.0)
@@ -699,7 +701,7 @@ class TestEverything(unittest.TestCase):
 
         for _ in self.simple: one.fill(_)
 
-        self.assertEqual(map(lambda x_c: (x_c[0], x_c[1].entries),one.bins), [(-3.85, 2.0), (-1.1666666666666667, 3.0), (0.8, 2.0), (2.8, 2.0), (7.3, 1.0)])
+        self.assertEqual(list(map(lambda x_c: (x_c[0], x_c[1].entries),one.bins)), [(-3.85, 2.0), (-1.1666666666666667, 3.0), (0.8, 2.0), (2.8, 2.0), (7.3, 1.0)])
 
         self.checkJson(one)
         self.checkPickle(one)

--- a/python/test/test.py
+++ b/python/test/test.py
@@ -308,23 +308,25 @@ class TestEverything(unittest.TestCase):
 
     def testAverageWithWeightingFactor(self):
         for i in xrange(11):
-            left, right = self.struct[:i], self.struct[i:]
 
+            left, right = self.struct[:i], self.struct[i:]
+            
             leftAveraging = Select(lambda x: x.int, Average(lambda x: x.double))
             rightAveraging = Select(lambda x: x.int, Average(lambda x: x.double))
-
+            
             for _ in left: leftAveraging.fill(_)
             for _ in right: rightAveraging.fill(_)
 
-            self.assertAlmostEqual(leftAveraging.value.mean, self.meanWeighted(map(lambda _: _.double, left), map(lambda _: _.int, left)))
-            self.assertAlmostEqual(rightAveraging.value.mean, self.meanWeighted(map(lambda _: _.double, right), map(lambda _: _.int, right)))
+            self.assertAlmostEqual(leftAveraging.value.mean, self.meanWeighted(list(map(lambda _: _.double, left)), list(map(lambda _: _.int, left))))
+            self.assertAlmostEqual(rightAveraging.value.mean, self.meanWeighted(list(map(lambda _: _.double, right)), list(map(lambda _: _.int, right))))
 
             finalResult = leftAveraging + rightAveraging
 
-            self.assertAlmostEqual(finalResult.value.mean, self.meanWeighted(map(lambda _: _.double, self.struct), map(lambda _: _.int, self.struct)))
+            self.assertAlmostEqual(finalResult.value.mean, self.meanWeighted(list(map(lambda _: _.double, self.struct)), list(map(lambda _: _.int, self.struct))))
 
             self.checkJson(leftAveraging)
             self.checkPickle(leftAveraging)
+
 
     ################################################################ Deviate
 
@@ -378,12 +380,12 @@ class TestEverything(unittest.TestCase):
             for _ in left: leftDeviating.fill(_)
             for _ in right: rightDeviating.fill(_)
 
-            self.assertAlmostEqual(leftDeviating.value.variance, self.varianceWeighted(map(lambda _: _.double, left), map(lambda _: _.int, left)))
-            self.assertAlmostEqual(rightDeviating.value.variance, self.varianceWeighted(map(lambda _: _.double, right), map(lambda _: _.int, right)))
+            self.assertAlmostEqual(leftDeviating.value.variance, self.varianceWeighted(list(map(lambda _: _.double, left)), list(map(lambda _: _.int, left))))
+            self.assertAlmostEqual(rightDeviating.value.variance, self.varianceWeighted(list(map(lambda _: _.double, right)), list(map(lambda _: _.int, right))))
 
             finalResult = leftDeviating + rightDeviating
 
-            self.assertAlmostEqual(finalResult.value.variance, self.varianceWeighted(map(lambda _: _.double, self.struct), map(lambda _: _.int, self.struct)))
+            self.assertAlmostEqual(finalResult.value.variance, self.varianceWeighted(list(map(lambda _: _.double, self.struct)), list(map(lambda _: _.int, self.struct))))
 
             self.checkJson(leftDeviating)
             self.checkPickle(leftDeviating)

--- a/python/test/test.py
+++ b/python/test/test.py
@@ -699,7 +699,7 @@ class TestEverything(unittest.TestCase):
 
         for _ in self.simple: one.fill(_)
 
-        self.assertEqual(map(lambda (x, c): (x, c.entries), one.bins), [(-3.85, 2.0), (-1.1666666666666667, 3.0), (0.8, 2.0), (2.8, 2.0), (7.3, 1.0)])
+        self.assertEqual(map(lambda x_c: (x_c[0], x_c[1].entries),one.bins), [(-3.85, 2.0), (-1.1666666666666667, 3.0), (0.8, 2.0), (2.8, 2.0), (7.3, 1.0)])
 
         self.checkJson(one)
         self.checkPickle(one)


### PR DESCRIPTION
I made several changes that allow for python 2/3 compatibility. 

In util.py basestring, xrange and long are redefined if python 3 is used. 

The way lambdas unpack tuples has changed slightly in python 3, but it is possible to do it in a way that works in 2 and 3. Several changes have been made here.

Function attributes can no longer be called as e.g. "func_name" in python 3 but as "__name__", but this works in python 2 as well so it's an easy change.

In test.py in several places I had to force iterators to return lists.

In two places in primitives/collection.py a view is cast to list. 

